### PR TITLE
Fix for gdImageStringFT, was always using background color

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.6
+  - "0.12"
+  - "0.10"
+  - "0.8"
 before_install:
   - "sudo apt-get install libgd2-xpm-dev"

--- a/cpp/node-gd.cpp
+++ b/cpp/node-gd.cpp
@@ -1086,7 +1086,7 @@ private:
       NanScope();
 
       if (return_rectangle) {
-        err = gdImageStringFT(NULL, &brect[0], 0, *font, size, angle, x, y, *str);
+        err = gdImageStringFT(NULL, &brect[0], color, *font, size, angle, x, y, *str);
         if (err) return NanThrowError(err);
 
         Local<Array> result = NanNew<Array>();

--- a/cpp/node-gd.cpp
+++ b/cpp/node-gd.cpp
@@ -1052,7 +1052,7 @@ private:
       char *err;
       NanScope();
 
-      err = gdImageStringFT(NULL, &brect[0], 0, *font, size, angle, x, y, *str);
+      err = gdImageStringFT(NULL, &brect[0], color, *font, size, angle, x, y, *str);
       if (err) return NanThrowError(err);
 
       Local<Array> result = NanNew<Array>();


### PR DESCRIPTION
Adding text to a newly created image never resulted in text within an image since the background color was used as font color.